### PR TITLE
feat: render dynamic el tag name

### DIFF
--- a/docs/comps/resizable.md
+++ b/docs/comps/resizable.md
@@ -16,6 +16,10 @@ The children of `Resizable` should always be a single element, and the width and
 Config the width and height of the `Resizable` component instead of the children element.
 :::
 
+:::tip
+You can use the `as` prop to change the tag of the `Resizable` component, and the default is `div`.
+:::
+
 ```vue
 <script setup lang="ts">
 import { Resizable } from 'vue-resizables'

--- a/src/components/resizable.tsx
+++ b/src/components/resizable.tsx
@@ -1,5 +1,5 @@
-import type { IntrinsicElementAttributes, PropType } from 'vue'
-import { defineComponent, onMounted, ref } from 'vue'
+import type { NativeElements, PropType } from 'vue'
+import { defineComponent, h, onMounted, ref } from 'vue'
 import type { ResizableConfig } from '..'
 import { useResizable } from '@/_internal'
 
@@ -11,7 +11,7 @@ export const Resizable = defineComponent({
       default: () => ({}),
     },
     as: {
-      type: String as PropType<keyof IntrinsicElementAttributes>,
+      type: String as PropType<(keyof NativeElements) | (NonNullable<unknown> & string)>,
       default: 'div',
     },
   },
@@ -24,10 +24,6 @@ export const Resizable = defineComponent({
       useResizable(wrapperRef.value, props.config)
       init = true
     })
-    return () => {
-      return <props.as class="relative" ref={wrapperRef}>
-        {slots.default?.()}
-      </props.as>
-    }
+    return () => h(props.as, { class: 'relative', ref: wrapperRef }, slots.default?.())
   },
 })

--- a/src/components/resizable.tsx
+++ b/src/components/resizable.tsx
@@ -1,4 +1,4 @@
-import type { PropType } from 'vue'
+import type { IntrinsicElementAttributes, PropType } from 'vue'
 import { defineComponent, onMounted, ref } from 'vue'
 import type { ResizableConfig } from '..'
 import { useResizable } from '@/_internal'
@@ -9,6 +9,10 @@ export const Resizable = defineComponent({
     config: {
       type: Object as PropType<ResizableConfig>,
       default: () => ({}),
+    },
+    as: {
+      type: String as PropType<keyof IntrinsicElementAttributes>,
+      default: 'div',
     },
   },
   setup(props, { slots }) {
@@ -21,9 +25,9 @@ export const Resizable = defineComponent({
       init = true
     })
     return () => {
-      return <div class="relative" ref={wrapperRef}>
+      return <props.as class="relative" ref={wrapperRef}>
         {slots.default?.()}
-      </div>
+      </props.as>
     }
   },
 })


### PR DESCRIPTION
Purpose:
- This PR is to render dynamic elements using the `as` prop.

Situation:
- The prop type is to be `keyof IntrinsicElementAttributes`. 
- Although it has a type of declaration, it will render `<abc></abc>` when the `as="abc"`.
- It may need to evaluate the necessity of more strict type constraints.

related:
- https://cn.vuejs.org/api/built-in-special-elements.html#component
